### PR TITLE
Follow-up: remove testbucket202605031523-169049008132-ap-northeast-1-an resources

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,13 +1,1 @@
-resource "aws_s3_bucket" "test" {
-  bucket           = "testbucket202605031523-169049008132-ap-northeast-1-an"
-  bucket_namespace = "account-regional"
-}
-
-resource "aws_s3_bucket_public_access_block" "test" {
-  bucket = aws_s3_bucket.test.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
+# S3 bucket resources removed per PR follow-up request.


### PR DESCRIPTION
### Motivation
- Remove Terraform-managed test S3 bucket and its public access block per the follow-up request to delete `testbucket202605031523-169049008132-ap-northeast-1-an`.
- Prevent accidental provisioning or drift of the temporary test resources in this repo.

### Description
- Replaced the contents of `s3.tf` with a single comment noting that the S3 resources were removed per the follow-up request.
- Deleted the `aws_s3_bucket.test` resource from the Terraform configuration.
- Deleted the dependent `aws_s3_bucket_public_access_block.test` resource from the Terraform configuration.

### Testing
- Attempted to run `terraform fmt -check -recursive`, but the check could not run because `terraform` is not installed in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f124caf883328a57b2f37bf5f0ea)