### PR TITLE
[Follow-up] アカウント+リージョン名前空間のランダムS3バケット作成を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # sandbox-tf
+
+Terraform configuration that creates an S3 bucket with a random suffix in an account-and-region namespace.

--- a/s3.tf
+++ b/s3.tf
@@ -1,1 +1,15 @@
-# S3 bucket resources removed per PR follow-up request.
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "regional_namespace_bucket" {
+  bucket = "${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-${random_string.bucket_suffix.result}"
+}
+
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  lower   = true
+  numeric = true
+  special = false
+  upper   = false
+}

--- a/version.tf
+++ b/version.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "6.43.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.2"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- 元の依頼に対して、アカウントIDとリージョンを名前空間に含みつつランダムなサフィックスを付与したS3バケットをTerraformで作成する実装を追加するための変更です。

### Description
- `s3.tf` に `data "aws_caller_identity" "current" {}` と `data "aws_region" "current" {}` を追加しました。 
- `random_string` リソースを追加して8文字（小文字+数字）のランダムサフィックスを生成するようにしました。 
- `aws_s3_bucket` リソース `regional_namespace_bucket` を追加し、バケット名を `<account_id>-<region>-<random_suffix>` 形式で生成するようにしました。 
- `version.tf` の `required_providers` に `hashicorp/random` を追加し、`README.md` を現在の構成に合わせて更新し、変更をコミットしてフォローアップPRを作成しました。

### Testing
- `terraform fmt -check -diff && terraform init -backend=false -input=false && terraform validate` の実行は `terraform: command not found` により失敗しました。 
- `git add` と `git commit` は正常に実行され、変更はローカルでコミットされました。 
- フォローアップPRはスクリプト（`make_pr`）で作成されました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f2454c2c833289a70a99e2d69010)