### PR TITLE
Add EC2 instance provisioning without Elastic IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # sandbox-tf
 
-Terraform configuration that creates an S3 bucket with a random suffix in an account-and-region namespace.
+Terraform configuration that creates an S3 bucket with a random suffix in an account-and-region namespace and provisions one EC2 instance (without an Elastic IP).

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,23 @@
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+resource "aws_instance" "main" {
+  ami           = data.aws_ami.amazon_linux_2023.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "sandbox-ec2"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple sandbox configuration that provisions a single EC2 instance in addition to the existing S3 resources, explicitly without allocating an Elastic IP.

### Description
- Added `ec2.tf` which looks up the latest Amazon Linux 2023 AMI via `data.aws_ami` and defines one `aws_instance` resource named `main`.
- The instance uses `t3.micro` and is tagged `Name = "sandbox-ec2"` to identify the sandbox instance.
- Updated `README.md` to mention that the configuration now provisions one EC2 instance and that no Elastic IP is created or associated.

### Testing
- Attempted to run `terraform fmt` in the workspace but the `terraform` binary is not available in this environment (`terraform: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f0a522cc83328fae74fb381f8c86)